### PR TITLE
ensure fonts.dir is present on all images

### DIFF
--- a/alpine-3/build/system.sh
+++ b/alpine-3/build/system.sh
@@ -19,6 +19,7 @@ mkdir -pv /usr/share/fonts/cascadia-code
 cd /tmp
 wget https://github.com/microsoft/cascadia-code/releases/download/v2407.24/CascadiaCode-2407.24.zip
 unzip CascadiaCode-2407.24.zip
+mkfontdir
 mv -v otf/static/* /usr/share/fonts/cascadia-code/
 rm -rfv /tmp/* /var/cache/apk/*
 fc-cache -f -v

--- a/packages.yaml
+++ b/packages.yaml
@@ -53,6 +53,7 @@ packages:
     rhel: libXfixes   
   - debian: libxext6  # X11 library providing basic extensions like input/output, fonts, and display extensions.
     rhel: libXext   
+  - rhel: xorg-x11-fonts-100dpi
   - debian: libxcursor1  # X11 library that provides support for managing mouse cursors.
     rhel: libXcursor   
   - debian: libxau6  # X11 library used to manage authentication for X11 connections.


### PR DESCRIPTION
This ensures fonts.dir expected by KASM (see: [the issue](https://github.com/juno-fx/Helios/issues/64)] is always present.

I validated ubuntu&debian images are already OK via `find /usr/share -name "fonts.dir"`.

closes #64 
