### PR TITLE
move TLS handling out of Helios

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -132,6 +132,7 @@ RUN chmod -R 7777 /etc/s6-overlay/s6-rc.d/
 COPY LICENSE /LICENSE
 
 EXPOSE 3000
+EXPOSE 3001
 
 RUN rm -rf /.hold
 

--- a/common/root/opt/helios/nginx.conf
+++ b/common/root/opt/helios/nginx.conf
@@ -4,6 +4,8 @@ http {
     server {
       listen 3000 ssl;
       listen [::]:3000 ssl;
+      listen 3001;
+      listen [::]:3001;
       ssl_certificate           /opt/helios/ssl/cert.pem;
       ssl_certificate_key       /opt/helios/ssl/cert.key;
       location SUBFOLDER {


### PR DESCRIPTION
This should instead be provided by K8s components (eg. Cilium or Istio), making it transparent to the application

Until we sunset old ingress resources, I will keep both http and https ports available.

The reason for having both is we hardcode the HTTPs backend scheme in ingress resources - we must keep the port available until that has been phased out.