### PR TITLE
test authing git through gh cli

### DIFF
--- a/.github/workflows/sync-forks.yml
+++ b/.github/workflows/sync-forks.yml
@@ -45,8 +45,8 @@ jobs:
           for repo in $TARGET_REPOS; do
             echo "Syncing $repo"
             git remote remove ${repo} || true
-            git remote add ${repo} https://x-oauth-token:${GH_TOKEN}@github.com/${TARGET_ORG}/${repo}.git
-            git push ${repo} HEAD:sync-${short_sha}
+            gh auth setup-git
+            git remote add ${repo} https://x-access-token:${GH_TOKEN}@github.com/${TARGET_ORG}/${repo}.git
             gh pr create \
               --repo ${TARGET_ORG}/${repo} \
               --base main \


### PR DESCRIPTION
This has recently stopped working.

The settings page says it no longer works with public repos.

I want to try and see if we get a better error out of the gh cli or if it will perhaps pass (it probably won't - I didn't find much other detail on what could have broken in the GH changelog, so giving it a try - I think the warning in the settings about public repos is new, but not  sure)
