### PR TITLE
make sure the GH app is used in auth

### DIFF
--- a/.github/workflows/sync-forks.yml
+++ b/.github/workflows/sync-forks.yml
@@ -48,7 +48,6 @@ jobs:
           echo git config --local user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.generate-token.outputs.app-slug }}[bot]@users.noreply.github.com'
           git config --local user.name '${{ steps.generate-token.outputs.app-slug }}[bot]'
           git config --local user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.generate-token.outputs.app-slug }}[bot]@users.noreply.github.com'
-          git config --list | grep helper
           # We must ditch all the cred details the checkout action fills in
           # otherwise this conflicts with our basic auth passed in the remote and fails to push
           git config --local credential.helper ""


### PR DESCRIPTION
Despite what the UI started saying in the settings, this auth still works fine.
    
The root cause seems to come from the global/local gitconfigs both not
cooperating. Adjusting the behavior of both here (by cloning with the
 token and then forcing the push commands to ignore $HOME/.gitconfig )
